### PR TITLE
Introduce "EWP unique academic term identifier"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Examples
 ```xml
 <academic-term>
     <academic-year-id>2008/2009</academic-year-id>
+    <ewp-id>2008/2009-2/2</ewp-id>
     <display-name xml:lang="pl">Semestr letni 2008/2009</display-name>
     <display-name xml:lang="en">Spring semester 2008/2009</display-name>
     <start-date>2009-02-18</start-date>

--- a/schema.xsd
+++ b/schema.xsd
@@ -47,6 +47,85 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="EwpAcademicTermId">
+        <xs:annotation>
+            <xs:documentation>
+                Experimental identifier scheme which aims at uniquely identifying academic
+                terms. It is experimental because we are not 100% sure if *all* possible
+                academic terms used throughout the world can be uniquely identified by this
+                identifier. We are however quite sure that *most* can (the regular ones -
+                semesters, trimesters etc.). Discuss here:
+                https://github.com/erasmus-without-paper/ewp-specs-types-academic-term/issues/1
+
+
+                Naming guidelines
+                -----------------
+
+                Please note, that many institutions will use other kinds of identifiers for
+                their academic terms, and we don't want any unnecessary confusion here. For
+                this reason, if you decide to use this format (both within and outside of EWP),
+                then:
+
+                * Please refer to it as "EWP unique academic term identifier", or simply
+                  "EWP identifier" (when used within the context of a specific academic term).
+                * Avoid referring to it by "academic term identifier" (because it may be vague
+                  without the EWP specifier).
+                * If possible, please add a reference pointing the reader to the original EWP
+                  specifications of the EwpAcademicTermId data type (e.g. by importing
+                  EwpAcademicTermId in your XSD, or adding a link to the GitHub repository in
+                  your JavaDocs, etc.)
+
+
+                Specification
+                -------------
+
+                EWP academic terms identifiers have the form of the following string:
+
+                AcademicYearId-TermNumber/NumberOfTerms
+
+                where:
+
+                - AcademicYearId is the identifier of the academic year which this academic
+                  term is part of. The format of this identifier is described in the
+                  AcademicYearId simpleType (e.g. "2008/2009" or "2008/2008").
+
+                - NumberOfTerms identifies the *type* of this academic term. It does so by
+                  indicating the total number of academic terms of this type which occur within
+                  a single academic year. For example: "2" means a semester, because there are
+                  2 semesters within a single academic year.
+
+                - TermNumber MUST be less or equal to NumberOfTerms, and it indicates the
+                  number of this particualar academic term (within this academic year).
+
+                Both TermNumber and NumberOfTerms are integers. In practice, we don't think
+                they will ever reach a number greater than 4, but currently this format allows
+                them to be integers between 1 and 9.
+
+
+                Examples
+                --------
+
+                - "2008/2009-1/1" - the whole academic year 2008/2009,
+                - "2008/2009-1/2" - the first semester of this academic year (autumn semester),
+                - "2008/2009-2/2" - the second semester of this academic year (spring semester),
+                - "2008/2009-1/3" - the first trimester of this academic year,
+                - etc.
+
+                Note, that these identifiers also work on the southern hemisphere, though a bit
+                differently:
+
+                - "2008/2008-1/1" - the whole academic year 2008,
+                - "2008/2008-1/2" - the first semester of this academic year (spring semester),
+                - "2008/2008-2/2" - the first semester of this academic year (autumn semester),
+                - "2008/2008-1/4" - the first quadrimester of this academic year,
+                - etc.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{4}/[0-9]{4}-[1-9]/[1-9]"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:element name="academic-term">
         <xs:complexType>
             <xs:sequence>
@@ -58,6 +137,26 @@
                             Server developers: Please note that the list of all possible IDs is *preset* by
                             EWP (see AcademicYearId documentation). We are NOT refering to an internal IDs
                             some of you might perhaps have in your local databases!
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="ewp-id" minOccurs="0" maxOccurs="1" type="EwpAcademicTermId">
+                    <xs:annotation>
+                        <xs:documentation>
+                            EWP unique academic term identifier. It is RECOMMENDED for server developers to
+                            provide it, if possible. If given, then it MUST start with the same academic
+                            year identifier as was provided in the `academic-year-id` element.
+
+                            You might wonder, why it's only recommended, instead of being required`:
+
+                            - It's because we're currently not sure if this identifier can be provided for
+                              all possible academic terms. It is somewhat experimental (read about it in
+                              EwpAcademicTermId specification).
+
+                            - Also, this element has been added to this specification after it has been
+                              released as stable - this means that adding new required elements is not
+                              backward compatible. Note however, that this element MAY become required in
+                              future major releases of this specification.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>


### PR DESCRIPTION
Proposed fix for the feature request described here:
https://github.com/erasmus-without-paper/ewp-specs-types-academic-term/issues/1
(based on solution 1 described in the original thread)